### PR TITLE
Updated Naming Conventions per Dictionary

### DIFF
--- a/src/templates/dataSource/dataSource.hbs
+++ b/src/templates/dataSource/dataSource.hbs
@@ -31,11 +31,11 @@ func dataSource{{pascal packageName}}Read(ctx context.Context, d *schema.Resourc
 		{{name}}Id, resp, retryable, err := proxy.get{{pascal packageName}}IdByName(ctx, name)
 
 		if err != nil && !retryable {
-			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("Error searching {{english packageName}} %s | error: %s", name, err), resp))
+			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("Error searching {{english packageName}} %s | error: %s", name, err), resp))
 		}
 
 		if retryable {
-			return retry.RetryableError(util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("No {{english packageName}} found with name %s", name), resp))
+			return retry.RetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("No {{english packageName}} found with name %s", name), resp))
 		}
 
 		d.SetId({{name}}Id)

--- a/src/templates/resource/resource.hbs
+++ b/src/templates/resource/resource.hbs
@@ -39,11 +39,11 @@ func getAllAuth{{pascal packageName}}s(ctx context.Context, clientConfig *platfo
 
 	{{name}}s, resp, err := proxy.getAll{{pascal packageName}}(ctx)
 	if err != nil {
-		return nil, util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("Failed to get {{english packageName}}: %v", err), resp)
+		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get {{english packageName}}: %v", err), resp)
 	}
 
 	for _, {{name}} := range *{{name}}s {
-		resources[*{{name}}.Id] = &resourceExporter.ResourceMeta{Name: *{{name}}.Name}
+		resources[*{{name}}.Id] = &resourceExporter.ResourceMeta{BlockLabel: *{{name}}.Name}
 	}
 
 	return resources, nil
@@ -67,7 +67,7 @@ func create{{pascal packageName}}(ctx context.Context, d *schema.ResourceData, m
 	log.Printf("Creating {{english packageName}} %s", *{{packageName}}.Name)
 	{{name}}, resp, err := proxy.create{{pascal packageName}}(ctx, &{{packageName}})
 	if err != nil {
-		return util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("Failed to create {{english packageName}}: %s", err), resp)
+		return util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to create {{english packageName}}: %s", err), resp)
 	}
 
 	d.SetId(*{{name}}.Id)
@@ -87,7 +87,7 @@ func read{{pascal packageName}}(ctx context.Context, d *schema.ResourceData, met
 	{{else}}
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := get{{pascal packageName}}Proxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, Resource{{pascal packageName}}(), constants.DefaultConsistencyChecks, resourceName)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, Resource{{pascal packageName}}(), constants.ConsistencyChecks(), resourceName)
 
 	log.Printf("Reading {{english packageName}} %s", d.Id())
 
@@ -95,9 +95,9 @@ func read{{pascal packageName}}(ctx context.Context, d *schema.ResourceData, met
 		{{name}}, resp, getErr := proxy.get{{pascal packageName}}ById(ctx, d.Id())
 		if getErr != nil {
 			if util.IsStatus404(resp) {
-				return retry.RetryableError(util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("Failed to read {{english packageName}} %s: %s", d.Id(), getErr), resp))
+				return retry.RetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("Failed to read {{english packageName}} %s: %s", d.Id(), getErr), resp))
 			}
-			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("Failed to read {{english packageName}} %s: %s", d.Id(), getErr), resp))
+			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("Failed to read {{english packageName}} %s: %s", d.Id(), getErr), resp))
 		}
 
 		{{#each properties~}}{{#if flattenFunction~}}
@@ -135,7 +135,7 @@ func update{{pascal packageName}}(ctx context.Context, d *schema.ResourceData, m
 	log.Printf("Updating {{english packageName}} %s", *{{packageName}}.Name)
 	{{name}}, resp, err := proxy.update{{pascal packageName}}(ctx, d.Id(), &{{packageName}})
 	if err != nil {
-		return util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("Failed to update {{english packageName}} %s: %s", d.Id(), err), resp)
+		return util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to update {{english packageName}} %s: %s", d.Id(), err), resp)
 	}
 
 	log.Printf("Updated {{english packageName}} %s", *{{name}}.Id)
@@ -157,7 +157,7 @@ func delete{{pascal packageName}}(ctx context.Context, d *schema.ResourceData, m
 	
 	resp, err := proxy.delete{{pascal packageName}}(ctx, d.Id())
 	if err != nil {
-		return util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("Failed to delete {{english packageName}} %s: %s", d.Id(), err), resp)
+		return util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to delete {{english packageName}} %s: %s", d.Id(), err), resp)
 	}
 
 	return util.WithRetries(ctx, 180*time.Second, func() *retry.RetryError {
@@ -168,10 +168,10 @@ func delete{{pascal packageName}}(ctx context.Context, d *schema.ResourceData, m
 				log.Printf("Deleted {{english packageName}} %s", d.Id())
 				return nil
 			}
-			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("Error deleting {{english packageName}} %s: %s", d.Id(), err), resp))
+			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("Error deleting {{english packageName}} %s: %s", d.Id(), err), resp))
 		}
 
-		return retry.RetryableError(util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("{{english packageName}} %s still exists", d.Id()), resp))
+		return retry.RetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("{{english packageName}} %s still exists", d.Id()), resp))
 	})
 	{{/if}}
 	{{/unless}}

--- a/src/templates/schema/schema.hbs
+++ b/src/templates/schema/schema.hbs
@@ -20,10 +20,10 @@ const resourceName = "genesyscloud_{{snake packageName}}"
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
-	regInstance.RegisterResource(resourceName, Resource{{pascal packageName}}())
+	regInstance.RegisterResource(ResourceType, Resource{{pascal packageName}}())
 	{{#unless noGetAll}}
-	regInstance.RegisterDataSource(resourceName, DataSource{{pascal packageName}}())
-	regInstance.RegisterExporter(resourceName, {{pascal packageName}}Exporter())
+	regInstance.RegisterDataSource(ResourceType, DataSource{{pascal packageName}}())
+	regInstance.RegisterExporter(ResourceType, {{pascal packageName}}Exporter())
 	{{/unless}}
 }
 

--- a/src/templates/tests/initTest.hbs
+++ b/src/templates/tests/initTest.hbs
@@ -29,7 +29,7 @@ func (r *registerTestInstance) registerTestResources() {
 	r.resourceMapMutex.Lock()
 	defer r.resourceMapMutex.Unlock()
 
-	providerResources[resourceName] = Resource{{pascal packageName}}()
+	providerResources[ResourceType] = Resource{{pascal packageName}}()
 	// TODO: Add references
 }
 
@@ -38,7 +38,7 @@ func (r *registerTestInstance) registerTestDataSources() {
 	r.datasourceMapMutex.Lock()
 	defer r.datasourceMapMutex.Unlock()
 
-	providerDataSources[resourceName] =  DataSource{{pascal packageName}}()
+	providerDataSources[ResourceType] =  DataSource{{pascal packageName}}()
 	// TODO: Add references
 }
 


### PR DESCRIPTION
Fixes #4 

- Replace "{Name" with "{BlockLabel"
- Replace "constants.DefaultConsistencyChecks" with "constants.ConsistencyChecks()"
- Replace "(resourceName" with "(ResourceType"
- Replace "[resourceName" with "[ResourceType"
